### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#bannedwords－违禁词，敏感词库
+# bannedwords－违禁词，敏感词库
 论坛、社交网站、博客、微博等允许用户生成内容的网站，常常遇到屏蔽违禁词、敏感词、广告、色情等文字的问题。这里给出一份违禁词列表，供大家参考。
 
 共分以下几类：
@@ -8,12 +8,12 @@
 * 广告
 * 脏话
 
-#在线检查工具
+# 在线检查工具
 [http://www.text.wiki/check_block_words.html](http://www.text.wiki/check_block_words.html)
 
 ![敏感词在线检查工具截图](http://ww4.sinaimg.cn/mw1024/7ed0a961jw1f6aw9m923xj211w0tsgni.jpg)
 
-#如何使用
+# 如何使用
 发布违禁词本身就是违禁的。。。所以生成的词库都用base64编码。
 大家使用时，可以用 decrypt.php filename 解码，例如：
 
@@ -27,7 +27,7 @@ pub_sms_banned_words.txt.out.txt文件里即是违禁词。
 所有词库均来自网络，或利用爬虫抓取公开数据得到。
 使用者不得将此词库用于非法目的。
 
-#ChangeLog
+# ChangeLog
 2016-04-17 发布短信专用违禁词库，共2696条。
 
 2016-04-16 发布第一份违禁词库，共1673条。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
